### PR TITLE
added a __enter__ and __exit__ method to the Reader class so that it …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ docs/_build
 vcf/cparse.c
 vcf/cparse.so
 .coverage
+
+# virtualenv
+.venv
+
+# test data
+test_data/


### PR DESCRIPTION
Added a __enter__ and __exit__ method to the Reader class so that it can be used with a context manager. This change was made to address the potential bug from this open issue in the original repository where it is ambiguous if the filehandle ever gets closed

 To accomplish this I moved all logic that uses the self._reader attribute into the __enter__ method. I added the xopen which can handle streaming and compressed files implicitly. This dependency allowed me to remove some of the extra lines of code to handle compressed files. Using xopen also allowed me to change from having a fsock argument in the Reader class to just a input_filename argument that handles both streams and file objects.