### PR TITLE
Changed record.sample attribute to dictionary

### DIFF
--- a/vcf/parser.py
+++ b/vcf/parser.py
@@ -581,7 +581,7 @@ class Reader(object):
             samp_fmt._nums.append(entry_num)
         return samp_fmt
 
-    def _parse_samples(self, samples, samp_fmt, site):
+    def _parse_samples(self, samples, samp_fmt, site) -> dict[str, _Call]:
         """Parse a sample entry according to the format specified in the FORMAT
         column.
 
@@ -599,7 +599,7 @@ class Reader(object):
                 self.samples, samples, samp_fmt, samp_fmt._types, samp_fmt._nums, site
             )
 
-        samp_data = []
+        samp_data = {}
         _map = self._map
 
         nfields = len(samp_fmt._fields)
@@ -652,7 +652,7 @@ class Reader(object):
 
             # create a call object
             call = _Call(site, name, samp_fmt(*sampdat))
-            samp_data.append(call)
+            samp_data[name] = call
 
         return samp_data
 


### PR DESCRIPTION
converted the record.samples property from a list to a dictionary because I need to look up objects based on key value pairs. Users can just use the .values() property to maintain pipelines they have previously been using. BREAKING CHANGE